### PR TITLE
Replaced the text box with a syntax highlighting editor

### DIFF
--- a/Helpers/Scintilla/JsonFormatter.cs
+++ b/Helpers/Scintilla/JsonFormatter.cs
@@ -1,0 +1,49 @@
+﻿using System.Drawing;
+using EasyScintilla.Stylers;
+using ScintillaNET;
+
+namespace Xamasoft.JsonClassGenerator.UI.Helpers
+{
+    internal class JsonStyler : ScintillaStyler
+    {
+        public JsonStyler() : base(Lexer.Json) { }
+
+        public override void ApplyStyle(Scintilla scintilla)
+        {
+            scintilla.Styles[Style.Json.Default].ForeColor = Color.Black;
+            scintilla.Styles[Style.Json.Default].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.Number].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Json.Number].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.BlockComment].ForeColor = Color.DarkGreen;
+            scintilla.Styles[Style.Json.BlockComment].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.EscapeSequence].ForeColor = Color.Green;
+            scintilla.Styles[Style.Json.EscapeSequence].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.Error].ForeColor = Color.OrangeRed;
+            scintilla.Styles[Style.Json.Error].BackColor = Color.Beige;
+
+            scintilla.Styles[Style.Json.Operator].ForeColor = Color.Red;
+            scintilla.Styles[Style.Json.Operator].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.String].ForeColor = Color.Green;
+            scintilla.Styles[Style.Json.String].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.PropertyName].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Json.PropertyName].BackColor = Color.White;
+
+            scintilla.Styles[Style.Json.Keyword].ForeColor = Color.Chocolate;
+            scintilla.Styles[Style.Json.Keyword].BackColor = Color.White;
+
+            scintilla.Styles[21].ForeColor = Color.Black;
+            scintilla.Styles[21].BackColor = ColorTranslator.FromHtml("#A6CAF0");
+        }
+
+        public override void RemoveStyle(Scintilla scintilla) { }
+
+        public override void SetKeywords(Scintilla scintilla) { }
+
+    }
+}

--- a/JsonClassGenerator.csproj
+++ b/JsonClassGenerator.csproj
@@ -53,8 +53,16 @@
     <ApplicationIcon>json-csharp-icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EasyScintilla, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\EasyScintilla.1.0.3\lib\net40\EasyScintilla.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -84,6 +92,7 @@
     <Compile Include="frmClassGenerator.Designer.cs">
       <DependentUpon>frmClassGenerator.cs</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\Scintilla\JsonFormatter.cs" />
     <Compile Include="Program.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/frmClassGenerator.Designer.cs
+++ b/frmClassGenerator.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmCSharpClassGeneration));
             this.btnGenerate = new System.Windows.Forms.Button();
-            this.edtJson = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.lblNamespace = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
@@ -73,18 +72,20 @@
             this.loadJsonFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveJsonFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveJsonAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeJsonFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.closeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.jsonToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteGoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.generateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.validateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openDlg = new System.Windows.Forms.OpenFileDialog();
             this.saveDlg = new System.Windows.Forms.SaveFileDialog();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.validateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.closeJsonFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.edtJson = new EasyScintilla.SimpleEditor();
+            this.lblPosition = new System.Windows.Forms.Label();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
             this.flowLayoutPanel3.SuspendLayout();
@@ -102,24 +103,10 @@
             this.btnGenerate.UseVisualStyleBackColor = true;
             this.btnGenerate.Click += new System.EventHandler(this.btnGenerate_Click);
             // 
-            // edtJson
-            // 
-            this.edtJson.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.edtJson.Location = new System.Drawing.Point(15, 286);
-            this.edtJson.MaxLength = 10000000;
-            this.edtJson.Multiline = true;
-            this.edtJson.Name = "edtJson";
-            this.edtJson.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.edtJson.Size = new System.Drawing.Size(725, 302);
-            this.edtJson.TabIndex = 14;
-            this.edtJson.KeyDown += new System.Windows.Forms.KeyEventHandler(this.edtJson_KeyDown);
-            // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 270);
+            this.label1.Location = new System.Drawing.Point(12, 260);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(199, 13);
             this.label1.TabIndex = 6;
@@ -549,6 +536,13 @@
             this.saveJsonAsMenuItem.Text = "Save Json &As";
             this.saveJsonAsMenuItem.Click += new System.EventHandler(this.SaveJsonFileAs_Clicked);
             // 
+            // closeJsonFileMenuItem
+            // 
+            this.closeJsonFileMenuItem.Name = "closeJsonFileMenuItem";
+            this.closeJsonFileMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.closeJsonFileMenuItem.Text = "&Close Json File";
+            this.closeJsonFileMenuItem.Click += new System.EventHandler(this.btnCloseJsonFile_Clicked);
+            // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
@@ -589,32 +583,6 @@
             this.generateMenuItem.Text = "&Generate";
             this.generateMenuItem.Click += new System.EventHandler(this.btnGenerate_Click);
             // 
-            // helpToolStripMenuItem
-            // 
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.aboutMenuItem});
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.helpToolStripMenuItem.Text = "&Help";
-            // 
-            // aboutMenuItem
-            // 
-            this.aboutMenuItem.Name = "aboutMenuItem";
-            this.aboutMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.aboutMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.aboutMenuItem.Text = "&About";
-            this.aboutMenuItem.Click += new System.EventHandler(this.btnAbout_Click);
-            // 
-            // openDlg
-            // 
-            this.openDlg.Filter = "JSON files (*,json)|*.json|All files (*.*)|*.*";
-            this.openDlg.Title = "Select JSON file";
-            // 
-            // saveDlg
-            // 
-            this.saveDlg.Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*";
-            this.saveDlg.Title = "Save JSON file";
-            // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
@@ -628,18 +596,64 @@
             this.validateMenuItem.Text = "&Validate";
             this.validateMenuItem.Click += new System.EventHandler(this.btnValidate_Clicked);
             // 
-            // closeJsonFileMenuItem
+            // helpToolStripMenuItem
             // 
-            this.closeJsonFileMenuItem.Name = "closeJsonFileMenuItem";
-            this.closeJsonFileMenuItem.Size = new System.Drawing.Size(185, 22);
-            this.closeJsonFileMenuItem.Text = "&Close Json File";
-            this.closeJsonFileMenuItem.Click += new System.EventHandler(this.btnCloseJsonFile_Clicked);
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aboutMenuItem});
+            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Text = "&Help";
+            // 
+            // aboutMenuItem
+            // 
+            this.aboutMenuItem.Name = "aboutMenuItem";
+            this.aboutMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            this.aboutMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.aboutMenuItem.Text = "&About";
+            this.aboutMenuItem.Click += new System.EventHandler(this.btnAbout_Click);
+            // 
+            // openDlg
+            // 
+            this.openDlg.Filter = "JSON files (*,json)|*.json|All files (*.*)|*.*";
+            this.openDlg.Title = "Select JSON file";
+            // 
+            // saveDlg
+            // 
+            this.saveDlg.Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*";
+            this.saveDlg.Title = "Save JSON file";
+            // 
+            // edtJson
+            // 
+            this.edtJson.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.edtJson.IndentationGuides = ScintillaNET.IndentView.LookBoth;
+            this.edtJson.Location = new System.Drawing.Point(15, 276);
+            this.edtJson.Name = "edtJson";
+            this.edtJson.Size = new System.Drawing.Size(725, 311);
+            this.edtJson.Styler = null;
+            this.edtJson.TabIndex = 43;
+            this.edtJson.KeyDown += new System.Windows.Forms.KeyEventHandler(this.edtJson_KeyDown);
+            this.edtJson.KeyUp += new System.Windows.Forms.KeyEventHandler(this.EditorPositionChanged);
+            this.edtJson.MouseClick += new System.Windows.Forms.MouseEventHandler(this.EditorPositionChanged);
+            // 
+            // lblPosition
+            // 
+            this.lblPosition.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblPosition.AutoSize = true;
+            this.lblPosition.Location = new System.Drawing.Point(15, 589);
+            this.lblPosition.Name = "lblPosition";
+            this.lblPosition.Size = new System.Drawing.Size(30, 13);
+            this.lblPosition.TabIndex = 44;
+            this.lblPosition.Text = "0 / 0";
             // 
             // frmCSharpClassGeneration
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(752, 628);
+            this.Controls.Add(this.lblPosition);
+            this.Controls.Add(this.edtJson);
             this.Controls.Add(this.chkSortMembers);
             this.Controls.Add(this.chkDocumentationExamples);
             this.Controls.Add(this.btnPasteAndGo);
@@ -667,7 +681,6 @@
             this.Controls.Add(this.lblNamespace);
             this.Controls.Add(this.edtNamespace);
             this.Controls.Add(this.label1);
-            this.Controls.Add(this.edtJson);
             this.Controls.Add(this.btnGenerate);
             this.Controls.Add(this.MainMenu);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -695,7 +708,6 @@
         #endregion
 
         private System.Windows.Forms.Button btnGenerate;
-        private System.Windows.Forms.TextBox edtJson;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TextBox edtNamespace;
         private System.Windows.Forms.Label lblNamespace;
@@ -749,6 +761,8 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem validateMenuItem;
         private System.Windows.Forms.ToolStripMenuItem closeJsonFileMenuItem;
+        private EasyScintilla.SimpleEditor edtJson;
+        private System.Windows.Forms.Label lblPosition;
     }
 }
 

--- a/frmClassGenerator.cs
+++ b/frmClassGenerator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Newtonsoft.Json.Linq;
 using Xamasoft.JsonClassGenerator.CodeWriters;
+using Xamasoft.JsonClassGenerator.UI.Helpers;
 using Xamasoft.JsonClassGenerator.UI.Properties;
 
 
@@ -21,6 +22,14 @@ namespace Xamasoft.JsonClassGenerator.UI
             this.Font = SystemFonts.MessageBoxFont;
 
             Program.InitAppServices();
+            InitialiseSyntaxHighlightingEditor();
+        }
+
+        private void InitialiseSyntaxHighlightingEditor()
+        {
+            edtJson.Styler = new JsonStyler();              // The thing that sets Json syntax highlighting
+            edtJson.Text = string.Empty;                    // Clear any developer entered dummy data
+            edtJson.SetSavePoint();                         // Show the buffer has not been changed.
         }
 
         private void btnBrowse_Click(object sender, EventArgs e)
@@ -292,7 +301,7 @@ namespace Xamasoft.JsonClassGenerator.UI
             if (e.Control && e.KeyCode == Keys.A)
             {
                 edtJson.SelectionStart = 0;
-                edtJson.SelectionLength = edtJson.TextLength;
+                edtJson.SelectionEnd = edtJson.TextLength;
                 e.Handled = true;
             }
         }
@@ -315,7 +324,8 @@ namespace Xamasoft.JsonClassGenerator.UI
             {
                 edtJson.Text = File.ReadAllText(fileToRead);
                 edtJson.Tag = fileToRead;
-                edtJson.Modified = false;
+                edtJson.SetSavePoint();
+                UpdateCursorPosition();
             }
             catch (Exception ex)
             {
@@ -336,7 +346,8 @@ namespace Xamasoft.JsonClassGenerator.UI
 
             edtJson.Text = string.Empty;
             edtJson.Tag = null;
-            edtJson.Modified = false;
+            edtJson.SetSavePoint();
+            UpdateCursorPosition();
         }
 
         private void SaveJsonFile()
@@ -363,7 +374,8 @@ namespace Xamasoft.JsonClassGenerator.UI
             try
             {
                 File.WriteAllText(edtJson.Tag.ToString(), edtJson.Text);
-                edtJson.Modified = false;
+                edtJson.SetSavePoint();
+                UpdateCursorPosition();
             }
             catch (Exception ex)
             {
@@ -426,6 +438,13 @@ namespace Xamasoft.JsonClassGenerator.UI
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
+
+        private void EditorPositionChanged(object sender, EventArgs e) { UpdateCursorPosition(); }
+        private void UpdateCursorPosition()
+        {
+            lblPosition.Text = $"{edtJson.CurrentLine + 1}/{edtJson.GetColumn(edtJson.CurrentPosition) + 1}";
+        }
+
 
         #endregion
 

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EasyScintilla" version="1.0.3" targetFramework="net452" />
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The previous edit window was a simple text box, which did nothing to help edit the json. This has been replaced with the EasyScintilla component. This gives me a simple to use 'proper' editor:

![image](https://user-images.githubusercontent.com/21052696/29749065-ea4f782c-8b1b-11e7-8923-698875bd54fb.png)

The editor window (1) provides simple syntax highlighting and supports using the tab key for indenting text. On the left we have line numbers (2) which help with locating any errors that the json validator displays. The editor supports collapsing (3) of the text to reduce what is on screen.

Matching braces (4) are highlighted when you move your cursor to the opening or closing brace. Finally, the current cursor position(5) is displayed under the edit window which, again, is useful if an error has been indicated by the json validator.

**Note** This change introduces a new package to the UI project. If the code does not immediately compile, it means that Visual Studio has not detected the package change. You will need to manually update. Open the solution in Visual Studio, right click on the _solution_ and select the _Restore NuGet Packages_ option.